### PR TITLE
update length for cac

### DIFF
--- a/covid_app/templates/covid_app/event_list.html
+++ b/covid_app/templates/covid_app/event_list.html
@@ -9,7 +9,7 @@
     <form action="/scan/" method="post" class="scan-new">{% csrf_token %}
         <div class="input-group input-group-lg">
             <span class="input-group-text" id="inputGroup-sizing-lg">Scanner</span>
-            <input type="text" class="form-control" aria-label="Scanner input" name="scanner"
+            <input type="text" class="form-control" aria-label="Scanner input" name="scanner" minlength="87"
                    aria-describedby="inputGroup-sizing-lg" placeholder="Scan CAC here..." autofocus required>
         </div>
         <input type="hidden" name="location" value="{{ loc.0.pk }}">

--- a/covid_app/templates/covid_app/set_location.html
+++ b/covid_app/templates/covid_app/set_location.html
@@ -8,7 +8,7 @@
     <form action="/set_location/" method="post" class="scan-new">{% csrf_token %}
         <div class="input-group input-group-lg">
             <span class="input-group-text" id="inputGroup-sizing-lg">Set Location</span>
-            <input type="text" class="form-control" aria-label="Location input" name="location" minlength="87"
+            <input type="text" class="form-control" aria-label="Location input" name="location"
                    aria-describedby="inputGroup-sizing-lg" placeholder="Input Location..." autofocus required>
         </div>
     </form>


### PR DESCRIPTION
Bug: Setting the location required a min length of 87. (wrong input)

Solution: Set min length to Scan portion and removed from location setting.
